### PR TITLE
Add support for u8string

### DIFF
--- a/include/minidocx/word/main/paragraph.hpp
+++ b/include/minidocx/word/main/paragraph.hpp
@@ -44,6 +44,7 @@ namespace MINIDOCX_NAMESPACE
     RichTextPointer addRichText(const char* text);
     inline RichTextPointer addRichText(const char8_t* text) { return addRichText(reinterpret_cast<const char*>(text)); }
     RichTextPointer addRichText(std::string text);
+    inline RichTextPointer addRichText(std::u8string text) { return addRichText(std::string(reinterpret_cast<const char*>(text.c_str()), text.size())); }
 
     PicturePointer addPicture(const RelationshipId id);
 

--- a/include/minidocx/word/main/richtext.hpp
+++ b/include/minidocx/word/main/richtext.hpp
@@ -26,6 +26,9 @@ namespace MINIDOCX_NAMESPACE
 
     RichText(std::string text)
       : Run(RunType::RichText), text_{ std::move(text) } {}
+	  
+    RichText(std::u8string text)
+      : RichText(std::string(reinterpret_cast<const char*>(text.c_str()), text.size())) {}
 
     ~RichText() override = default;
     
@@ -41,6 +44,7 @@ namespace MINIDOCX_NAMESPACE
     inline void setText(const char* text) { text_ = text; }
     inline void setText(const char8_t* text) { setText(reinterpret_cast<const char*>(text)); }
     inline void setText(std::string text) { text_ = std::move(text); }
+    inline void setText(std::u8string text) { setText(std::string(reinterpret_cast<const char*>(text.c_str()), text.size())); }
 
   public:
     void clear() override


### PR DESCRIPTION
While u8string is poorly supported in C++20, it is a part of the standard and should be supported in some part. This is just a change to the headers. It gives a function definition to addRichText that takes a u8string and casts the data to string using reinterpret_cast. Similar to how char8_t pointers are handled. I didn't test it extensively but I found it simplifies working with utf-8 strings 