### PR TITLE
Add support for mingw64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,54 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# vcpkg
+vcpkg
+
+# build directory
+[Bb][Uu][Ii][Ll][Dd]
 /out
+
+# Macos
+.DS_Store
+
+# vscode
+.vscode
+
+# visual studio
+.vs
+
+# CMakeUserPresets
 CMakeUserPresets.json
+
+# Word Docs
 *.docx

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,6 +40,24 @@
           "sourceDir": "$env{HOME}/Projects/$ms{projectDirName}"
         }
       }
+    },
+    {
+      "name": "x64-win-ninja-gcc",
+      "inherits": "x64-linux-ninja-gcc",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "linux-gcc-x64"
+        }
+      }
     }
   ],
   "buildPresets": [
@@ -51,6 +69,16 @@
     {
       "name": "x64-win-msbuild-v143-release",
       "configurePreset": "x64-win-msbuild-v143",
+      "configuration": "Release"
+    },
+    {
+      "name": "x64-win-ninja-gcc-debug",
+      "configurePreset": "x64-win-ninja-gcc",
+      "configuration": "Debug"
+    },
+    {
+      "name": "x64-win-ninja-gcc-release",
+      "configurePreset": "x64-win-ninja-gcc",
       "configuration": "Release"
     },
     {

--- a/src/packaging/package.cpp
+++ b/src/packaging/package.cpp
@@ -14,6 +14,8 @@
 #endif
 #include <sstream>
 
+// for strcmp
+#include <cstring>
 
 namespace MINIDOCX_NAMESPACE
 {

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -5,13 +5,13 @@
  */
 
 #include "utils/string.hpp"
-
+#include <algorithm>
 
 namespace MINIDOCX_NAMESPACE
 {
   std::string removeSpaces(std::string str) {
     std::string tmp{ std::move(str) };
-    tmp.erase(std::remove_if(tmp.begin(), tmp.end(), std::isspace), tmp.end());
+    tmp.erase(std::remove_if(tmp.begin(), tmp.end(), [](unsigned char x) {return std::isspace(x); }), tmp.end());
     return tmp;
   }
 }

--- a/src/utils/zip.cpp
+++ b/src/utils/zip.cpp
@@ -14,6 +14,8 @@
 #include <memory>
 #include <sstream>
 
+// for memmove
+#include <cstring>
 
 namespace MINIDOCX_NAMESPACE
 {


### PR DESCRIPTION
- Added cstring into zip.cpp and package,cpp. MSVC's implementation of the stdlib includes cstring in string, where as libstdc++ and also libc++ (clang) do not.
- Updated the gitignore to handle macos and .vs directories
- Add a cmake preset for mingw64
- fixed a argument deduction error for remove_if in string,cpp
this closes #39 