### PR TITLE
Bug fix for RichTextProperties.whitespace_

### DIFF
--- a/src/word/main/document.cpp
+++ b/src/word/main/document.cpp
@@ -554,7 +554,10 @@ namespace MINIDOCX_NAMESPACE
         }
       }
       if (start < end) {
-        w_r.append_child("w:t").text().set(start);
+          pugi::xml_node w_t = w_r.append_child("w:t");
+          if (whitespace)
+              w_t.append_attribute("xml:space") = "preserve";
+          w_t.text().set(start);
       }
     }
   }


### PR DESCRIPTION
Bug fix: Allow preserving leading or trailing space characters if RichTextProperties.whitespace_ is true